### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,27 @@
 Enforces that a library's components are all versioned.
 
 #### For example:
-| What | Incorrect | Correct |
-| --- | --- | --- |
-| Artifact name | lib-stats | lib-stats-__v2__ |
-| Packages | com.rallyhealth.stats.Stats | com.rallyhealth.stats.__v2__.Stats |
-| Directories | com/rallyhealth/stats/Stats | com/rallyhealth/stats/__v2__/Stats |
+
+| What          | Incorrect                   | Correct                            |
+| ------------- | --------------------------- | ---------------------------------- |
+| Artifact name | lib-stats                   | lib-stats-**v2**                   |
+| Packages      | com.rallyhealth.stats.Stats | com.rallyhealth.stats.**v2**.Stats |
+| Directories   | com/rallyhealth/stats/Stats | com/rallyhealth/stats/**v2**/Stats |
 
 Mitigates runtime dependency hell by enabling multiple incompatible major versions of a library to coexist together safely.
 
 ## Setup
+
 Add the latest [release](https://github.com/AudaxHealthInc/sbt-shading/releases) to your plugins.sbt:
 
 plugins.sbt
+
 ```
 addSbtPlugin("com.rallyhealth.sbt" %% "sbt-shading" % "x.y.z")
 ```
 
 build.sbt
+
 ```
 lazy val `lib-stats` = project
   .enablePlugins(ShadingPlugin)
@@ -27,34 +31,39 @@ lazy val `lib-stats` = project
 
 Add `v2` to your packages:
 
-| Incorrect | Correct
-| --- | --- |
-| src/__main__/scala/com/rallyhealth/foo/... | src/__main__/scala/com/rallyhealth/foo/__v2__... |
-| src/__test__/scala/com/rallyhealth/foo/... | src/__test__/scala/com/rallyhealth/foo/__v2__... |
-| src/__it__/scala/com/rallyhealth/foo/...   | src/__it__/scala/com/rallyhealth/foo/__v2__... |
+| Incorrect                                  | Correct                                          |
+| ------------------------------------------ | ------------------------------------------------ |
+| src/**main**/scala/com/rallyhealth/foo/... | src/**main**/scala/com/rallyhealth/foo/**v2**... |
+| src/**test**/scala/com/rallyhealth/foo/... | src/**test**/scala/com/rallyhealth/foo/**v2**... |
+| src/**it**/scala/com/rallyhealth/foo/...   | src/**it**/scala/com/rallyhealth/foo/**v2**...   |
 
 ## Usage
+
 Shading is checked automatically during the following SBT tasks
-* publish
-* test
+
+- publish
+- test
 
 Shading is not checked during `compile` because it does not affect compilation: your code
 should compile fine whether it is shaded or not. Shading is a correctness test (like unit
 tests).
 
 If you want to check shading yourself you can run
+
 ```
-sbt> shadingCheck
-```
-or
-```
-$ sbt shadingCheck
+sbt> rallyShadingCheck
 ```
 
+or
+
+```
+$ sbt rallyShadingCheck
+```
 
 When the plugin detects a violation it will print something like this:
+
 ```
-sbt> shadingCheck
+sbt> rallyShadingCheck
 [trace] Stack trace suppressed: run last <project>/*:shadingCheckFiles for the full output.
 [error] (<project>/*:shadingCheckFiles) com.rallyhealth.sbt.shading.FileShadingErrorsException: Expected name shaded version "v2" for:
 [error] src/main/scala/com/rallyhealth/foo/Foo.scala: DirectoryUnshaded, PackageNameUnshaded(com.rallyhealth.foo)
@@ -65,27 +74,31 @@ sbt> shadingCheck
 ## Depending on shaded libraries
 
 If you are _depending_ on a shaded library you simply need to add the "v2" to the _artifact name_ of your `ModuleID` declaration:
+
 ```
 "com.rallyhealth.foo" %% "lib-stats-v2" % "2.0.0"
 ```
 
 To avoid repeating the version in two places -- the artifact and version -- you can use a handy implicit:
+
 ```
 import com.rallyhealth.sbt.shading.ShadingImplicits._
 
 "com.rallyhealth.foo" %% "lib-stats" % "2.0.0" shaded
 ```
 
-
 ## Why Semver is not enough
-[SemVer](http://semver.org/) alone will not save you from [Dependency Hell](https://en.wikipedia.org/wiki/Dependency_hell).  
+
+[SemVer](http://semver.org/) alone will not save you from [Dependency Hell](https://en.wikipedia.org/wiki/Dependency_hell).
 
 ### Major versions bring breaking changes.
+
 > 8. Major version X (X.y.z | X > 0) MUST be incremented if any backwards incompatible changes are introduced to the public API.
 >
 > -- <cite>http://semver.org/#spec-item-8</cite>
 
 ## A Song of Dependencies and Hell
+
 ### Chapter 1: Everything works
 
 Consider a library, `lib-stats % 1.0.0`, that records metrics. It has a `com.rallyhealth.stats.Stats.inc()` method that everybody loves. Your app uses `lib-http`, `lib-queue`, and `lib-akka` which make use of `lib-stats % 1.0.0` to send metrics, and life is good.
@@ -104,6 +117,7 @@ Consider a library, `lib-stats % 1.0.0`, that records metrics. It has a `com.ral
 You post the error to the Engineering room. They say "hurr hurr derpendencies," and tell you you'll have to clean up the mess. You need to ship this feature tomorrow. You cry.
 
 #### Evictions
+
 So what happened?
 
 1. Sbt evicted `lib-stats 1.0.0` in favor of the newer `lib-stats 2.0.0`. That's by design. Sbt will only keep the latest version of a library.
@@ -113,10 +127,13 @@ So what happened?
 There must be a better way.
 
 ### Chapter 3: A Solution Emerges
+
 #### Eliminating Evictions
+
 Can we prevent the eviction from happening? Yes! If we give the artifacts different names, they won't get evicted. Including the major version in the name, like `lib-stats-v2`, would do the trick quite nicely. This plugin enforces that.
 
 #### Preventing Namespace Conflicts
+
 So if both `lib-stats-v1` and `lib-stats-v2` are on the classpath, how do we keep them from having incompatible versions of `com.rallyhealth.stats.Stats`?
 
 Simple. This plugin enforces that you include `v2` in the package name. You'll end up with `com.rallyhealth.stats.v1.Stats` and `com.rallyhealth.stats.v2.Stats` living in harmony.
@@ -124,7 +141,8 @@ Simple. This plugin enforces that you include `v2` in the package name. You'll e
 ![Dependency graph. lib-stats v1 and v2 are both in the graph. All libraries have compatible dependencies.](readme/dependency-hell-shaded.png)
 
 ### Epilogue
-Your app uses only shaded internal libraries now.  You have two binary-incompatible versions of `lib-stats-v*` in your app, but you don't care. Everything works just fine.
+
+Your app uses only shaded internal libraries now. You have two binary-incompatible versions of `lib-stats-v*` in your app, but you don't care. Everything works just fine.
 
 One day you'll update `lib-http` and `lib-cache` to use the new `lib-stats-v2`, but not today. Your friends are heading to the bar, and you're free to join then.
 
@@ -133,6 +151,7 @@ Your phone vibrates and you see the !love from QA and your product owner telling
 You smile as you sip your gin and tonic. Dependency hell is the last thing on your mind.
 
 ## Errors
+
 If the artifact name, directories, or package names do not include the current major version, the [shading checks](https://github.com/AudaxHealthInc/sbt-shading/blob/master/src/main/scala/com/rallyhealth/sbt/shading/ShadingPlugin.scala#L22-L28) will fail the build when `test` or `publish` are run.
 
 ![screenshot of build output of all three types of shading errors](readme/screenshot.png)
@@ -140,19 +159,23 @@ If the artifact name, directories, or package names do not include the current m
 ## Caveats
 
 ### Renaming
+
 To upgrade from `lib-stats-v1` to `lib-stats-v2`, all classes that `import com.rallyhealth.stats.v1.Stats` will have to be updated to `import com.rallyhealth.stats.v2.Stats`.
 
 This may seem like a drawback at first, but it's actually a strength. Introducing breaking changes has become more expensive. They can often be avoided. There's incentive to do so now.
 
 ### Third party jars
+
 This plugin cannot protect you from unshaded third party libraries. For example, netty 3 does not play nicely with netty 4. However, third party libs move at much slower pace than Rally's internal libs. Historically, most of our pain has been self-induced via internal libs.
 
 ### Resource management
+
 Take care around using shading with global state and resource consumption (threads, external connections, etc.). For example, if your library acts as a global database connection pool, shading it opens the possibility of having multiple instances active at once and opening extra connections.
 
 If the consequences of duplicating global state is unacceptable, shading may not be the correct solution.
 
 ### Minor/Patch breakages
+
 This plugin only solves for breaking changes across major versions.
 
 [sbt-git-versioning](https://github.com/rallyhealth/sbt-git-versioning) complements this plugin by providing SemVer enforcement for minor/patch releases using the Typesafe [Migration Manager](https://github.com/typesafehub/migration-manager).
@@ -160,12 +183,14 @@ This plugin only solves for breaking changes across major versions.
 ## Alternatives
 
 ### OSGi
+
 A framework for managing components on the JVM. Requires running inside a third party OSGi server.
 
-* https://www.osgi.org/
-* https://en.wikipedia.org/wiki/OSGi
+- https://www.osgi.org/
+- https://en.wikipedia.org/wiki/OSGi
 
 ### Java 9: Project Jigsaw
+
 Released with Java 9. This solves a somewhat different problem: breaking down monolithic JARs -- namely the JDK --
 into smaller, more independent parts. It allows a JAR to more explicitly define what classes/packages are being exposed
 and what transitive dependencies are being shared with the consuming application.
@@ -174,29 +199,32 @@ Modules _can_ solve the problem of two different JARs each defining their own _i
 `ClassLoader` properly loading the correct class for each JAR. If the JARs properly declare `com.acme.Foo` as
 internal then there should be no conflict.
 
-Unfortunately modules do *not* solve the problem if both JARs expose their own `com.acme.Foo` definition. The
-`ClassLoader` will still have to guess. Modules also do *not* help if you depend on different versions of the
+Unfortunately modules do _not_ solve the problem if both JARs expose their own `com.acme.Foo` definition. The
+`ClassLoader` will still have to guess. Modules also do _not_ help if you depend on different versions of the
 same JAR since Jigsaw [explicitly does not handle versions](http://openjdk.java.net/projects/jigsaw/goals-reqs/03#versioning).
 
 TL;DR: Jigsaw is a _partial_ solution
 
-* [Home](http://openjdk.java.net/projects/jigsaw/)
-* [Quick Start](http://openjdk.java.net/projects/jigsaw/quick-start)
-* [Java Platform Module System (JSR 376)](http://openjdk.java.net/projects/jigsaw/spec/)
-* [Understanding Java 9 Modules](https://www.oracle.com/corporate/features/understanding-java-9-modules.html)
-* [Code First Java 9 Module System Tutorial](https://blog.codefx.org/java/java-module-system-tutorial/)
-* [What’s ahead with Java 9 & Project Jigsaw](https://www.dynatrace.com/news/blog/whats-ahead-with-java-9-project-jigsaw/)
-* [Java 9 Migration Guide: The Seven Most Common Challenges](https://blog.codefx.org/java/java-9-migration-guide/)
-* [The Top 10 Jigsaw and Java 9 Misconceptions Debunked](https://blog.takipi.com/the-top-10-jigsaw-and-java-9-misconceptions-debunked/)
-* [Is Jigsaw good or is it wack?](https://blog.plan99.net/is-jigsaw-good-or-is-it-wack-ec634d36dd6f)
+- [Home](http://openjdk.java.net/projects/jigsaw/)
+- [Quick Start](http://openjdk.java.net/projects/jigsaw/quick-start)
+- [Java Platform Module System (JSR 376)](http://openjdk.java.net/projects/jigsaw/spec/)
+- [Understanding Java 9 Modules](https://www.oracle.com/corporate/features/understanding-java-9-modules.html)
+- [Code First Java 9 Module System Tutorial](https://blog.codefx.org/java/java-module-system-tutorial/)
+- [What’s ahead with Java 9 & Project Jigsaw](https://www.dynatrace.com/news/blog/whats-ahead-with-java-9-project-jigsaw/)
+- [Java 9 Migration Guide: The Seven Most Common Challenges](https://blog.codefx.org/java/java-9-migration-guide/)
+- [The Top 10 Jigsaw and Java 9 Misconceptions Debunked](https://blog.takipi.com/the-top-10-jigsaw-and-java-9-misconceptions-debunked/)
+- [Is Jigsaw good or is it wack?](https://blog.plan99.net/is-jigsaw-good-or-is-it-wack-ec634d36dd6f)
 
 ### sbt-assembly shading
+
 sbt-assembly can do auto-shading of artifacts, but gets hairy with multi-project builds and IDE support.
 
-* https://github.com/sbt/sbt-assembly#shading
+- https://github.com/sbt/sbt-assembly#shading
 
 ## Maintainer
+
 You can ping [Doug Roper](mailto:doug.roper@rallyhealth.com) for any questions.
 
 ## Testing
+
 This plugin is tested by unit tests and with sbt's built-in [scripted plugin](http://eed3si9n.com/testing-sbt-plugins).


### PR DESCRIPTION
- Update `shadingCheck` to `rallyShadingCheck`, because `shadingCheck` does not work. 
```
sbt:lib-rx-ingest> shadingCheck
[error] Not a valid command: shadingCheck
[error] Not a valid project ID: shadingCheck
[error] Expected ':'
[error] Not a valid key: shadingCheck (similar: rallyShadingCheck, rallyShadingCheckFiles)
[error] shadingCheck
[error]             ^
```

- Made README prettier. 

Let me know if you don't like the README formatting. I can only update  `shadingCheck` -> `rallyShadingCheck` part.


